### PR TITLE
Introducing a new strategy for the tokenizer

### DIFF
--- a/include/string_utils.hpp
+++ b/include/string_utils.hpp
@@ -17,5 +17,6 @@ int count_char(SubString string, char chr);
 void find_first_position(std::string &string, char chr);
 void trim_substring(SubString &sub);
 
+std::string substring_to_string(SubString substring);
 void print_substring(SubString substring);
 std::vector<SubString> split_substring(SubString sub, const char delimiter);

--- a/include/string_utils.hpp
+++ b/include/string_utils.hpp
@@ -16,6 +16,7 @@ int count_char(std::string &string, char chr);
 int count_char(SubString string, char chr);
 void find_first_position(std::string &string, char chr);
 void trim_substring(SubString &sub);
+void trim_substring(Token &token);
 
 std::string substring_to_string(SubString substring);
 void print_substring(SubString substring);

--- a/include/tokenizer.hpp
+++ b/include/tokenizer.hpp
@@ -52,6 +52,7 @@ void parse_entry(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens);
+void parse_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_comma(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_open_bracket(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens);

--- a/include/tokenizer.hpp
+++ b/include/tokenizer.hpp
@@ -49,14 +49,14 @@ public:
 void tokenizer(ParserBuffer &parser_buffer, std::list<Token> &tokens);
 
 
-void parse_entry(ParserBuffer &buf, std::list<Token> &tokens);
-void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens);
-void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens);
-void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens);
-void parse_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens);
-void parse_comma(ParserBuffer &buf, std::list<Token> &tokens);
-void parse_open_bracket(ParserBuffer &buf, std::list<Token> &tokens);
-void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens);
-void parse_equal_sign(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_entry(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_entry_type(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_entry_body(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_comma(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_open_bracket(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_close_bracket(ParserBuffer &buf, std::list<Token> &tokens);
+void tokenize_equal_sign(ParserBuffer &buf, std::list<Token> &tokens);
 
 

--- a/include/tokenizer.hpp
+++ b/include/tokenizer.hpp
@@ -16,7 +16,8 @@ enum Tag
     COMMA = 5237,
     OPEN_BRACKET = 5238,
     CLOSE_BRACKET = 5239,
-    EQUAL_SIGN = 5340
+    EQUAL_SIGN = 5340,
+    QUOTATION_MARK = 5341
 };
 
 std::string tag_to_string(Tag tag);
@@ -58,5 +59,5 @@ void tokenize_comma(ParserBuffer &buf, std::list<Token> &tokens);
 void tokenize_open_bracket(ParserBuffer &buf, std::list<Token> &tokens);
 void tokenize_close_bracket(ParserBuffer &buf, std::list<Token> &tokens);
 void tokenize_equal_sign(ParserBuffer &buf, std::list<Token> &tokens);
-
+void tokenize_quotation_mark(ParserBuffer &buf, std::list<Token> &tokens);
 

--- a/include/tokenizer.hpp
+++ b/include/tokenizer.hpp
@@ -15,7 +15,8 @@ enum Tag
     BIB_ATTRIBUTE_KEY = 5236,
     COMMA = 5237,
     OPEN_BRACKET = 5238,
-    CLOSE_BRACKET = 5239
+    CLOSE_BRACKET = 5239,
+    EQUAL_SIGN = 5340
 };
 
 std::string tag_to_string(Tag tag);
@@ -56,6 +57,6 @@ void parse_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_comma(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_open_bracket(ParserBuffer &buf, std::list<Token> &tokens);
 void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens);
-
+void parse_equal_sign(ParserBuffer &buf, std::list<Token> &tokens);
 
 

--- a/include/tokenizer.hpp
+++ b/include/tokenizer.hpp
@@ -11,47 +11,50 @@ enum Tag
 {
     BIB_IDENTIFIER = 5234,
     BIB_TYPE = 5233,
-    BIB_ATTRIBUTE = 5235
+    BIB_ATTRIBUTE_VALUE = 5235,
+    BIB_ATTRIBUTE_KEY = 5236,
+    COMMA = 5237,
+    OPEN_BRACKET = 5238,
+    CLOSE_BRACKET = 5239
 };
 
-class Token {
-public:
-    Tag tag;
-    std::unordered_map<std::string, std::string> attributes;
-
-    Token (Tag input_tag, std::string input_key, std::string input_value);
-};
+std::string tag_to_string(Tag tag);
 
 struct SubString {
     std::string::iterator begin;
     std::string::iterator end;
 };
 
-struct EntryBody {
-    SubString identifier;
-    std::vector<SubString> attributes;
+struct ParserBuffer {
+    std::string::iterator begin;
+    std::string::iterator end;
+    std::string::iterator anchor;
+    std::string::iterator current_char;
 };
 
-struct EntryAttribute {
-    SubString key;
+
+class Token {
+public:
+    Tag tag;
     SubString value;
+
+    Token (Tag input_tag, SubString input_value);
+    std::string as_string();
+    SubString as_substring();
+    void print_token();
 };
 
 
-
-void tokenizer(std::string &file, std::list<Token> &tokens);
-Token build_token(Tag type_of_token, SubString lexeme);
-Token build_attribute_token(EntryAttribute attr);
+void tokenizer(ParserBuffer &parser_buffer, std::list<Token> &tokens);
 
 
-std::vector<SubString> collect_bib_entries(std::string &file);
-void parse_entry(SubString entry, std::list<Token> &tokens);
-SubString get_entry_type(SubString entry);
+void parse_entry(ParserBuffer &buf, std::list<Token> &tokens);
+void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens);
+void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens);
+void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens);
+void parse_comma(ParserBuffer &buf, std::list<Token> &tokens);
+void parse_open_bracket(ParserBuffer &buf, std::list<Token> &tokens);
+void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens);
 
 
-EntryBody parse_entry_body(SubString attrs);
-void print_entry_body (EntryBody body);
 
-
-std::vector<EntryAttribute> parse_entry_attributes(std::vector<SubString> &attrs);
-void print_entry_attributes (std::vector<EntryAttribute> attrs);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "read_bib.hpp"
 #include "tokenizer.hpp"
 #include "global_variables.hpp"
+#include "string_utils.hpp"
 
 
 int main(int argc, char *argv[])
@@ -20,8 +21,10 @@ int main(int argc, char *argv[])
 
     std::list<Token> tokens;
     tokenizer(parser_buffer, tokens);
+    
     for (Token token: tokens)
     {
+        trim_substring(token);
         token.print_token();
     }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,10 +20,10 @@ int main(int argc, char *argv[])
 
     std::list<Token> tokens;
     tokenizer(parser_buffer, tokens);
-    for (Token token: tokens)
-    {
-        token.print_token();
-    }
+    // for (Token token: tokens)
+    // {
+    //     token.print_token();
+    // }
     
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,10 +20,10 @@ int main(int argc, char *argv[])
 
     std::list<Token> tokens;
     tokenizer(parser_buffer, tokens);
-    // for (Token token: tokens)
-    // {
-    //     token.print_token();
-    // }
+    for (Token token: tokens)
+    {
+        token.print_token();
+    }
     
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,36 +7,23 @@
 #include "global_variables.hpp"
 
 
-void print_token(Token token)
-{
-    std::cout << "Token: "
-        << token.tag
-        << "   |   ";
-    
-    for (auto& it: token.attributes) {
-    // Do stuff
-        std::cout << it.first
-            << "   |   "
-            << it.second
-            << std::endl;
-    }
-
-}
-
-
-
-
 int main(int argc, char *argv[])
 {
     std::string path_to_file = get_path_to_file(argc, argv);
     std::string bib_file = read_bib_file(path_to_file);
 
+    ParserBuffer parser_buffer;
+    parser_buffer.begin = bib_file.begin();
+    parser_buffer.end = bib_file.end();
+    parser_buffer.anchor = bib_file.begin();
+    parser_buffer.current_char = bib_file.begin();
+
     std::list<Token> tokens;
-    tokenizer(bib_file, tokens);
-    // for (Token token: tokens)
-    // {
-    //     print_token(token);
-    // }
+    tokenizer(parser_buffer, tokens);
+    for (Token token: tokens)
+    {
+        token.print_token();
+    }
     
 }
 

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -105,6 +105,11 @@ void trim_substring(SubString &sub)
     std::string::iterator begin = sub.begin;
     std::string::iterator end = sub.end;
 
+    if (begin == end)
+    {
+        return;
+    }
+
     std::string::iterator current_char = begin;
     while (is_white_space(*(current_char + 1)))
     {
@@ -122,6 +127,36 @@ void trim_substring(SubString &sub)
     sub.begin = begin;
     sub.end = end;
 }
+
+void trim_substring(Token &token)
+{
+    std::string::iterator begin = token.value.begin;
+    std::string::iterator end = token.value.end;
+
+    if (begin == end)
+    {
+        return;
+    }
+
+    std::string::iterator current_char = begin;
+    while (is_white_space(*(current_char + 1)))
+    {
+        current_char++;
+    }
+    begin = current_char;
+
+    current_char = end;
+    while (is_white_space(*(current_char - 1)))
+    {
+        current_char--;
+    }
+    end = current_char;
+
+    token.value.begin = begin;
+    token.value.end = end;
+}
+
+
 
 std::string substring_to_string(SubString substring)
 {

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -123,12 +123,24 @@ void trim_substring(SubString &sub)
     sub.end = end;
 }
 
+std::string substring_to_string(SubString substring)
+{
+    std::string str;
+    if (substring.begin == substring.end)
+    {
+        str = std::string(1, *substring.end);
+    } 
+    else
+    {
+        str = std::string(substring.begin, substring.end);
+    }
+    return str;
+}
 
 
 void print_substring(SubString substring)
 {
-    std::string s = std::string(substring.begin, substring.end);
-    std::cout << s << std::endl;
+    std::cout << substring_to_string(substring) << std::endl;
 }
 
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -30,11 +30,16 @@ void Token::print_token()
 
 void tokenizer(ParserBuffer &buf, std::list<Token> &tokens)
 {
-    while (buf.current_char != buf.end)
+    while (true)
     {
         if (*buf.current_char == '@')
         {
             parse_entry(buf, tokens);
+        }
+        if (buf.current_char == buf.end)
+        {
+            std::cout << "Reached end of file!" << std::endl;
+            break;
         }
         buf.current_char++;
     }
@@ -51,7 +56,7 @@ void parse_entry(ParserBuffer &buf, std::list<Token> &tokens)
 void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
-    while (*buf.current_char != '{' | buf.current_char == buf.end)
+    while (*buf.current_char != '{' | buf.current_char != buf.end)
     {
         buf.current_char++;
     }
@@ -63,8 +68,8 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 {
     SubString substring;
     buf.anchor = buf.current_char;
-
-    while (*(buf.current_char + 1) != '@' | buf.current_char == buf.end)
+    
+    while (*(buf.current_char + 1) != '@' | buf.current_char != buf.end)
     {
         if (*buf.current_char == '{')
         {
@@ -74,7 +79,7 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
         buf.current_char++;
     }
 
-    while (*(buf.current_char + 1) != '@' | buf.current_char == buf.end)
+    while (*(buf.current_char + 1) != '@' | buf.current_char != buf.end)
     {
         if (*(buf.current_char + 1) == ',')
         {
@@ -85,7 +90,7 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
         buf.current_char++;
     }
 
-    // while (*(buf.current_char + 1) != '@' | buf.current_char == buf.end)
+    // while (*(buf.current_char + 1) != '@' | buf.current_char != buf.end)
     // {
     //     if (*buf.current_char == '{')
     //     {

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -7,216 +7,164 @@
 #include "string_utils.hpp"
 
 
-Token::Token (Tag input_tag, std::string input_key, std::string input_value)
+Token::Token (Tag input_tag, SubString input_value)
 {
     tag = input_tag;
-    attributes.emplace(input_key, input_value);
+    value = input_value;
+}
+
+std::string Token::as_string()
+{
+    std::string s_tag = tag_to_string(tag);
+    std::string s_value = substring_to_string(value);
+    std::string text = s_tag + "=" + s_value;
+    return text;
+}
+
+void Token::print_token()
+{
+    std::cout << Token::as_string() << std::endl;
 }
 
 
-Token build_token(Tag type_of_token, SubString lexeme)
+
+void tokenizer(ParserBuffer &buf, std::list<Token> &tokens)
 {
-    std::string key;
-    switch (type_of_token)
+    while (buf.current_char != buf.end)
     {
-    case BIB_TYPE:
-        key = "type";
+        if (*buf.current_char == '@')
+        {
+            parse_entry(buf, tokens);
+        }
+        buf.current_char++;
+    }
+
+}
+
+
+void parse_entry(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    parse_entry_type(buf, tokens);
+    parse_entry_body(buf, tokens);
+}
+
+void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    buf.anchor = buf.current_char;
+    while (*buf.current_char != '{' | buf.current_char == buf.end)
+    {
+        buf.current_char++;
+    }
+    SubString entry_type = {buf.anchor, buf.current_char};
+    tokens.emplace_back(Token(BIB_TYPE, entry_type));
+}
+
+void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    SubString substring;
+    buf.anchor = buf.current_char;
+
+    while (*(buf.current_char + 1) != '@' | buf.current_char == buf.end)
+    {
+        if (*buf.current_char == '{')
+        {
+            parse_open_bracket(buf, tokens);
+            break;
+        }
+        buf.current_char++;
+    }
+
+    while (*(buf.current_char + 1) != '@' | buf.current_char == buf.end)
+    {
+        if (*(buf.current_char + 1) == ',')
+        {
+            parse_bib_identifier(buf, tokens);
+            parse_comma(buf, tokens);
+            break;
+        }
+        buf.current_char++;
+    }
+
+    // while (*(buf.current_char + 1) != '@' | buf.current_char == buf.end)
+    // {
+    //     if (*buf.current_char == '{')
+    //     {
+    //         parse_open_bracket(buf, tokens);
+    //         continue;
+    //     }
+    //     if (*buf.current_char == '}')
+    //     {
+    //         parse_close_bracket(buf, tokens);
+    //         continue;
+    //     }
+    //     buf.current_char++;
+    // }
+}
+
+
+void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    SubString substring = {buf.anchor, buf.current_char};
+    tokens.emplace_back(Token(BIB_IDENTIFIER, substring));
+    buf.current_char++;
+}
+
+void parse_comma(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    buf.anchor = buf.current_char;
+    SubString substring = {buf.anchor, buf.current_char};
+    tokens.emplace_back(Token(COMMA, substring));
+    buf.current_char++;
+    buf.anchor = buf.current_char;
+}
+
+void parse_open_bracket(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    buf.anchor = buf.current_char;
+    SubString substring = {buf.anchor, buf.current_char};
+    tokens.emplace_back(Token(OPEN_BRACKET, substring));
+    buf.current_char++;
+    buf.anchor = buf.current_char;
+}
+
+void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    buf.anchor = buf.current_char;
+    SubString substring = {buf.anchor, buf.current_char};
+    tokens.emplace_back(Token(CLOSE_BRACKET, substring));
+    buf.current_char++;
+    buf.anchor = buf.current_char;
+}
+
+
+std::string tag_to_string(Tag tag)
+{
+    std::string s_tag;
+    switch (tag)
+    {
+    case BIB_ATTRIBUTE_VALUE:
+        s_tag = "BIB_ATTRIBUTE_VALUE";
+        break;
+    case BIB_ATTRIBUTE_KEY:
+        s_tag = "BIB_ATTRIBUTE_KEY";
         break;
     case BIB_IDENTIFIER:
-        key = "identifier";
+        s_tag = "BIB_IDENTIFIER";
+        break;
+    case BIB_TYPE:
+        s_tag = "BIB_TYPE";
+        break;
+    case COMMA:
+        s_tag = "COMMA";
+        break;
+    case OPEN_BRACKET:
+        s_tag = "OPEN_BRACKET";
+        break;
+    case CLOSE_BRACKET:
+        s_tag = "CLOSE_BRACKET";
         break;
     default:
         break;
     }
-
-    std::string value = std::string(lexeme.begin, lexeme.end);
-    Token token(type_of_token, key, value);
-    return token;
-}
-
-Token build_attribute_token(EntryAttribute attr)
-{
-    std::string key = std::string(attr.key.begin, attr.key.end);
-    std::string value = std::string(attr.value.begin, attr.value.end);
-    Token token(BIB_ATTRIBUTE, key, value);
-    return token;
-}
-
-
-void tokenizer(std::string &file, std::list<Token> &tokens)
-{
-    std::vector<SubString> bib_entries = collect_bib_entries(file);
-    std::for_each(bib_entries.begin(), bib_entries.end(), &trim_substring);
-
-    for (SubString entry : bib_entries)
-    {
-        parse_entry(entry, tokens);
-    }
-}
-
-
-
-
-
-std::vector<SubString> collect_bib_entries(std::string &file)
-{
-    int n_of_entries = count_char(file, '@');
-    std::vector<SubString> bib_entries;
-    bib_entries.reserve(n_of_entries);
-    
-    std::string::iterator begin = file.begin();
-    std::string::iterator end = file.end();
-    std::string::iterator current_char = begin;
-    int entry_number = 0;
-
-    while (current_char != end)
-    {
-        if (*current_char == '@' & entry_number == 0)
-        {
-            current_char++;
-            begin = current_char;
-            entry_number++;
-            continue;
-        }
-
-        if (*current_char == '@' & entry_number < n_of_entries)
-        {
-            SubString entry_adress = {begin, current_char};
-            bib_entries.emplace_back(entry_adress);
-            entry_number++;
-            current_char++;
-            begin = current_char;
-            continue;
-        }
-
-        // Get last bib entry in the file
-        if ((current_char + 1) == end)
-        {
-            SubString entry_adress = {begin, current_char};
-            bib_entries.emplace_back(entry_adress);
-            entry_number++;
-            current_char++;
-            begin = current_char;
-            break;
-        }
-
-        current_char++;
-    }
-
-    return bib_entries;
-}
-
-
-
-void parse_entry(SubString entry, std::list<Token> &tokens)
-{
-    SubString entry_type = get_entry_type(entry);
-    tokens.emplace_back(build_token(BIB_TYPE, entry_type));
-
-    std::string::iterator end = entry.end;
-    SubString substring_body = {entry_type.end, end};
-    EntryBody entry_body = parse_entry_body(substring_body);
-
-    tokens.emplace_back(build_token(BIB_IDENTIFIER, entry_body.identifier));
-
-    std::vector<EntryAttribute> entry_attributes = parse_entry_attributes(entry_body.attributes);
-    for (EntryAttribute attr: entry_attributes)
-    {
-        tokens.emplace_back(build_attribute_token(attr));
-    }
-}
-
-SubString get_entry_type(SubString entry)
-{
-    std::string::iterator current_char = entry.begin;
-    std::string::iterator begin = entry.begin;
-    std::string::iterator end = entry.end;
-
-    while (current_char != end)
-    {
-        if (*(current_char + 1) == '{')
-        {
-            break;
-        }
-
-        current_char++;
-    }
-
-    return {begin, current_char + 1};
-}
-
-
-
-EntryBody parse_entry_body(SubString body)
-{
-    print_substring(body);
-    EntryBody entry_body;
-    std::vector<SubString> substrings = split_substring(body, ',');
-    
-    if (substrings.size() == 1)
-    {
-        entry_body.identifier = substrings[0];
-        std::vector<SubString> empty_vector;
-        entry_body.attributes = empty_vector;
-        return entry_body;
-    }
-
-    entry_body.identifier = substrings[0];
-    substrings.erase(substrings.begin());
-    entry_body.attributes = substrings;
-
-    return entry_body;
-}
-
-std::vector<EntryAttribute> parse_entry_attributes(std::vector<SubString> &attrs)
-{
-    std::vector<EntryAttribute> attributes;
-    int n_attrs = attrs.size();
-    attributes.reserve(n_attrs);
-
-    const char delimiter = '=';
-    std::vector<SubString> substrings;
-    EntryAttribute attribute;
-
-    for (SubString attr: attrs)
-    {
-        substrings = split_substring(attr, delimiter);
-        std::for_each(substrings.begin(), substrings.end(), &trim_substring);
-        attribute.key = substrings[0];
-        attribute.value = substrings[1];
-        attributes.emplace_back(attribute);
-    }
-
-    return attributes;    
-}
-
-
-
-
-
-void print_entry_body (EntryBody body)
-{
-    std::cout << "[Entry Identifier]: ";
-    print_substring(body.identifier);
-
-    std::cout
-        << std::endl
-        << "[Entry Attributes]: "
-        << std::endl;
-
-    for (SubString attr: body.attributes)
-    {
-        print_substring(attr);
-    }
-}
-
-void print_entry_attributes (std::vector<EntryAttribute> attrs)
-{
-    for (EntryAttribute attr: attrs)
-    {
-        std::cout << "[Attribute key]: ";
-        std::cout << std::string(attr.key.begin, attr.key.end) << "   |   ";
-        std::cout << "[Attribute value]: ";
-        std::cout << std::string(attr.value.begin, attr.value.end) << std::endl;
-    } 
+    return s_tag;
 }

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -38,7 +38,7 @@ void tokenizer(ParserBuffer &buf, std::list<Token> &tokens)
         }
         if (buf.current_char == buf.end)
         {
-            std::cout << "Reached end of file!" << std::endl;
+            std::cout << "Tokenizer reached end of file!" << std::endl;
             break;
         }
         buf.current_char++;
@@ -56,21 +56,32 @@ void parse_entry(ParserBuffer &buf, std::list<Token> &tokens)
 void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
-    while (*buf.current_char != '{' | buf.current_char != buf.end)
+    while (buf.current_char != buf.end)
     {
+        if (*buf.current_char == '{')
+        {
+            break;
+        }
         buf.current_char++;
     }
+
     SubString entry_type = {buf.anchor, buf.current_char};
     tokens.emplace_back(Token(BIB_TYPE, entry_type));
 }
+
 
 void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 {
     SubString substring;
     buf.anchor = buf.current_char;
     
-    while (*(buf.current_char + 1) != '@' | buf.current_char != buf.end)
+    while (buf.current_char != buf.end)
     {
+        if (*(buf.current_char + 1) != '@')
+        {
+            return;
+        }
+
         if (*buf.current_char == '{')
         {
             parse_open_bracket(buf, tokens);
@@ -79,8 +90,13 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
         buf.current_char++;
     }
 
-    while (*(buf.current_char + 1) != '@' | buf.current_char != buf.end)
+    while (buf.current_char != buf.end)
     {
+        if (*(buf.current_char + 1) != '@')
+        {
+            return;
+        }
+
         if (*(buf.current_char + 1) == ',')
         {
             parse_bib_identifier(buf, tokens);
@@ -90,20 +106,33 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
         buf.current_char++;
     }
 
-    // while (*(buf.current_char + 1) != '@' | buf.current_char != buf.end)
-    // {
-    //     if (*buf.current_char == '{')
-    //     {
-    //         parse_open_bracket(buf, tokens);
-    //         continue;
-    //     }
-    //     if (*buf.current_char == '}')
-    //     {
-    //         parse_close_bracket(buf, tokens);
-    //         continue;
-    //     }
-    //     buf.current_char++;
-    // }
+    while (buf.current_char != buf.end)
+    {
+        if (*(buf.current_char + 1) != '@')
+        {
+            return;
+        }
+
+        if (*buf.current_char == '{')
+        {
+            parse_open_bracket(buf, tokens);
+            continue;
+        }
+
+        if (*buf.current_char == '}')
+        {
+            parse_close_bracket(buf, tokens);
+            continue;
+        }
+
+        if (*buf.current_char == ',')
+        {
+            parse_comma(buf, tokens);
+            continue;
+        }
+
+        buf.current_char++;
+    }
 }
 
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -34,7 +34,7 @@ void tokenizer(ParserBuffer &buf, std::list<Token> &tokens)
     {
         if (*buf.current_char == '@')
         {
-            parse_entry(buf, tokens);
+            tokenize_entry(buf, tokens);
         }
         if (buf.current_char == buf.end)
         {
@@ -47,13 +47,13 @@ void tokenizer(ParserBuffer &buf, std::list<Token> &tokens)
 }
 
 
-void parse_entry(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_entry(ParserBuffer &buf, std::list<Token> &tokens)
 {
-    parse_entry_type(buf, tokens);
-    parse_entry_body(buf, tokens);
+    tokenize_entry_type(buf, tokens);
+    tokenize_entry_body(buf, tokens);
 }
 
-void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_entry_type(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
     while (buf.current_char != buf.end)
@@ -70,7 +70,7 @@ void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens)
 }
 
 
-void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
 
@@ -83,7 +83,7 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 
         if (*buf.current_char == '{')
         {
-            parse_open_bracket(buf, tokens);
+            tokenize_open_bracket(buf, tokens);
             break;
         }
         buf.current_char++;
@@ -99,8 +99,8 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 
         if (*(buf.current_char + 1) == ',')
         {
-            parse_bib_identifier(buf, tokens);
-            parse_comma(buf, tokens);
+            tokenize_bib_identifier(buf, tokens);
+            tokenize_comma(buf, tokens);
             break;
         }
         buf.current_char++;
@@ -115,7 +115,7 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 
         if (*buf.current_char == '=')
         {
-            parse_entry_attribute(buf, tokens);
+            tokenize_entry_attribute(buf, tokens);
             continue;
         }
 
@@ -124,7 +124,7 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 }
 
 
-void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens)
 {
     SubString substring = {buf.anchor, buf.current_char + 1};
     tokens.emplace_back(Token(BIB_IDENTIFIER, substring));
@@ -135,7 +135,7 @@ void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens)
     buf.anchor = buf.current_char;
 }
 
-void parse_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
     while (buf.current_char != buf.begin)
@@ -150,7 +150,7 @@ void parse_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens)
     tokens.emplace_back(Token(BIB_ATTRIBUTE_KEY, attribute_key));
 
     buf.current_char = buf.anchor;
-    parse_equal_sign(buf, tokens);
+    tokenize_equal_sign(buf, tokens);
     char value_delimiter_open;
     char value_delimiter_end;
     // while (buf.current_char != buf.end)
@@ -169,7 +169,7 @@ void parse_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens)
     // }
 }
 
-void parse_comma(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_comma(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
     SubString substring = {buf.anchor, buf.current_char};
@@ -181,7 +181,7 @@ void parse_comma(ParserBuffer &buf, std::list<Token> &tokens)
     buf.anchor = buf.current_char;
 }
 
-void parse_open_bracket(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_open_bracket(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
     SubString substring = {buf.anchor, buf.current_char};
@@ -193,7 +193,7 @@ void parse_open_bracket(ParserBuffer &buf, std::list<Token> &tokens)
     buf.anchor = buf.current_char;
 }
 
-void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_close_bracket(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
     SubString substring = {buf.anchor, buf.current_char};
@@ -205,7 +205,7 @@ void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens)
     buf.anchor = buf.current_char;
 }
 
-void parse_equal_sign(ParserBuffer &buf, std::list<Token> &tokens)
+void tokenize_equal_sign(ParserBuffer &buf, std::list<Token> &tokens)
 {
     buf.anchor = buf.current_char;
     SubString substring = {buf.anchor, buf.current_char};

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -72,12 +72,11 @@ void parse_entry_type(ParserBuffer &buf, std::list<Token> &tokens)
 
 void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 {
-    SubString substring;
     buf.anchor = buf.current_char;
-    
+
     while (buf.current_char != buf.end)
     {
-        if (*(buf.current_char + 1) != '@')
+        if (*(buf.current_char + 1) == '@')
         {
             return;
         }
@@ -90,14 +89,15 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
         buf.current_char++;
     }
 
+
     while (buf.current_char != buf.end)
     {
-        if (*(buf.current_char + 1) != '@')
+        if (*(buf.current_char + 1) == '@')
         {
             return;
         }
 
-        if (*(buf.current_char + 1) == ',')
+        if (*buf.current_char == ',')
         {
             parse_bib_identifier(buf, tokens);
             parse_comma(buf, tokens);
@@ -108,7 +108,7 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 
     while (buf.current_char != buf.end)
     {
-        if (*(buf.current_char + 1) != '@')
+        if (*(buf.current_char + 1) == '@')
         {
             return;
         }
@@ -140,7 +140,11 @@ void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens)
 {
     SubString substring = {buf.anchor, buf.current_char};
     tokens.emplace_back(Token(BIB_IDENTIFIER, substring));
-    buf.current_char++;
+    if (buf.current_char != buf.end)
+    {
+        buf.current_char++;
+    }
+    buf.anchor = buf.current_char;
 }
 
 void parse_comma(ParserBuffer &buf, std::list<Token> &tokens)
@@ -148,7 +152,10 @@ void parse_comma(ParserBuffer &buf, std::list<Token> &tokens)
     buf.anchor = buf.current_char;
     SubString substring = {buf.anchor, buf.current_char};
     tokens.emplace_back(Token(COMMA, substring));
-    buf.current_char++;
+    if (buf.current_char != buf.end)
+    {
+        buf.current_char++;
+    }
     buf.anchor = buf.current_char;
 }
 
@@ -157,7 +164,10 @@ void parse_open_bracket(ParserBuffer &buf, std::list<Token> &tokens)
     buf.anchor = buf.current_char;
     SubString substring = {buf.anchor, buf.current_char};
     tokens.emplace_back(Token(OPEN_BRACKET, substring));
-    buf.current_char++;
+    if (buf.current_char != buf.end)
+    {
+        buf.current_char++;
+    }
     buf.anchor = buf.current_char;
 }
 
@@ -166,7 +176,10 @@ void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens)
     buf.anchor = buf.current_char;
     SubString substring = {buf.anchor, buf.current_char};
     tokens.emplace_back(Token(CLOSE_BRACKET, substring));
-    buf.current_char++;
+    if (buf.current_char != buf.end)
+    {
+        buf.current_char++;
+    }
     buf.anchor = buf.current_char;
 }
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -113,21 +113,9 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
             return;
         }
 
-        if (*buf.current_char == '{')
+        if (*buf.current_char == '=')
         {
-            parse_open_bracket(buf, tokens);
-            continue;
-        }
-
-        if (*buf.current_char == '}')
-        {
-            parse_close_bracket(buf, tokens);
-            continue;
-        }
-
-        if (*buf.current_char == ',')
-        {
-            parse_comma(buf, tokens);
+            parse_entry_attribute(buf, tokens);
             continue;
         }
 
@@ -145,6 +133,40 @@ void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens)
         buf.current_char++;
     }
     buf.anchor = buf.current_char;
+}
+
+void parse_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    buf.anchor = buf.current_char;
+    while (buf.current_char != buf.begin)
+    {
+        if (*(buf.current_char - 1) == ',')
+        {
+            break;
+        }
+        buf.current_char--;
+    }
+    SubString attribute_key = {buf.current_char, buf.anchor};
+    tokens.emplace_back(Token(BIB_ATTRIBUTE_KEY, attribute_key));
+
+    buf.current_char = buf.anchor;
+    buf.current_char++;
+    // char value_delimiter_open;
+    // char value_delimiter_end;
+    // while (buf.current_char != buf.end)
+    // {
+    //     if (*buf.current_char == '"')
+    //     {
+    //         value_delimiter_open = '"';
+    //         value_delimiter_end = '"';
+    //     }
+    //     if (*buf.current_char == '{')
+    //     {
+    //         value_delimiter_open = '{';
+    //         value_delimiter_end = '}';
+    //     }
+    //     buf.current_char++;       
+    // }
 }
 
 void parse_comma(ParserBuffer &buf, std::list<Token> &tokens)

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -97,7 +97,7 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
             return;
         }
 
-        if (*buf.current_char == ',')
+        if (*(buf.current_char + 1) == ',')
         {
             parse_bib_identifier(buf, tokens);
             parse_comma(buf, tokens);
@@ -138,7 +138,7 @@ void parse_entry_body(ParserBuffer &buf, std::list<Token> &tokens)
 
 void parse_bib_identifier(ParserBuffer &buf, std::list<Token> &tokens)
 {
-    SubString substring = {buf.anchor, buf.current_char};
+    SubString substring = {buf.anchor, buf.current_char + 1};
     tokens.emplace_back(Token(BIB_IDENTIFIER, substring));
     if (buf.current_char != buf.end)
     {

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -17,7 +17,7 @@ std::string Token::as_string()
 {
     std::string s_tag = tag_to_string(tag);
     std::string s_value = substring_to_string(value);
-    std::string text = s_tag + "=" + s_value;
+    std::string text = s_tag + ": " + s_value;
     return text;
 }
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -150,9 +150,9 @@ void parse_entry_attribute(ParserBuffer &buf, std::list<Token> &tokens)
     tokens.emplace_back(Token(BIB_ATTRIBUTE_KEY, attribute_key));
 
     buf.current_char = buf.anchor;
-    buf.current_char++;
-    // char value_delimiter_open;
-    // char value_delimiter_end;
+    parse_equal_sign(buf, tokens);
+    char value_delimiter_open;
+    char value_delimiter_end;
     // while (buf.current_char != buf.end)
     // {
     //     if (*buf.current_char == '"')
@@ -205,6 +205,18 @@ void parse_close_bracket(ParserBuffer &buf, std::list<Token> &tokens)
     buf.anchor = buf.current_char;
 }
 
+void parse_equal_sign(ParserBuffer &buf, std::list<Token> &tokens)
+{
+    buf.anchor = buf.current_char;
+    SubString substring = {buf.anchor, buf.current_char};
+    tokens.emplace_back(Token(EQUAL_SIGN, substring));
+    if (buf.current_char != buf.end)
+    {
+        buf.current_char++;
+    }
+    buf.anchor = buf.current_char; 
+}
+
 
 std::string tag_to_string(Tag tag)
 {
@@ -231,6 +243,9 @@ std::string tag_to_string(Tag tag)
         break;
     case CLOSE_BRACKET:
         s_tag = "CLOSE_BRACKET";
+        break;
+    case EQUAL_SIGN:
+        s_tag = "EQUAL_SIGN";
         break;
     default:
         break;


### PR DESCRIPTION
This PR brings some major changes to the current version of the tokenizer. The previous version of the tokenizer produces many and many copies of the pointers that represents each substring in the bib file. This is ok since we are just copying a pair of pointers. 

However, this new version avoids these copies by introducing a buffer for the tokenizer which is represented by the `ParserBuffer` struct. Furthermore, this PR introduce a new strategy for the tokenizer, that tries to tokenize more single characters in the chain. In other words, the previous version of the tokenizer could not create many tokens for single characters such as the equal sign (`=`), openning and closing brackets (`{`, `}`), quotation marks (`"`). As a consequence, the tokenizer, more or less, was ignoring these charaters while parsing.

By avoiding producing tokens for these single characters, we introduced some unnecessary complexity in the parsing strategy. As a consequence, this new version of the tokenizer can build tokens for these single characters, and have a more simpler approach to produce tokens for the larger parts (or the larger substrings) of each entry (e.g. the body, the attribute keys and values).